### PR TITLE
Split physics_mmm target in Makefile.mpas to allow separate library update

### DIFF
--- a/Makefile.mpas
+++ b/Makefile.mpas
@@ -1,5 +1,7 @@
 .SUFFIXES: .F90 .o
 
+.PHONY: physics_mmm physics_mmm_lib
+
 all: dummy physics_mmm
 
 dummy:
@@ -20,6 +22,8 @@ OBJS = \
 	module_libmassv.o
 
 physics_mmm: $(OBJS)
+
+physics_mmm_lib:
 	ar -ru ./../libphys.a $(OBJS)
 
 # DEPENDENCIES:


### PR DESCRIPTION
This PR splits the `physics_mmm` target in `Makefile.mpas` into to separate targets to allow MPAS-A to update the `libphys.a` library separately from the compilation of source files into object files. The `physics_mmm` target is now used to compile source files, while the `physics_mmm_lib` target is used for adding object files into MPAS-A's `libphys.a` library. This is important for parallel builds, in which MPAS-A may be building multiple sets of physics schemes in parallel, and including library updates within these compilation steps may lead to race conditions when updating `libphys.a`.