### PR TITLE
fix for possible uninitialized value of zol

### DIFF
--- a/sf_sfclayrev.F90
+++ b/sf_sfclayrev.F90
@@ -378,6 +378,8 @@
 
  do 320 i = its,ite
 !                                                                           
+    zol(i) = 0.
+!
     if(br(i).gt.0) then
        if(br(i).gt.250.0) then
           zol(i)=zolri(250.0,za(i),znt(i))


### PR DESCRIPTION
This fix duplicates a change made for WRF V3.6.1 in sf_sfclayrev.F90 