### PR TITLE
Fix overly downward mixing in ShinHong and YSU PBL

### DIFF
--- a/bl_shinhong.F90
+++ b/bl_shinhong.F90
@@ -1002,7 +1002,7 @@
                      - (thlix(i,k) + thx(i,k)  *ep1*(qvx(i,k)  +qcxl(i,k)))
            dthvx(i)  = max(dthvx(i),0.1)
            evp_fac   = xlv/cp * rcldb/(pi2d(i,k)*dthvx(i))
-           ent_eff   = min(0.2 * (1.+8.*evp_fac),scu_ent_max)
+           ent_eff   = min(0.2*8.*evp_fac,scu_ent_max)
 !
            radsum = 0.
            do kk = 1,k

--- a/bl_ysu.F90
+++ b/bl_ysu.F90
@@ -852,7 +852,7 @@
                           - (thlix(i,k) + thx(i,k)  *ep1*(qvx(i,k)  +qcxl(i,k)))
                 dthvx(i)  = max(dthvx(i),0.1)
                 tmp1      = xlv/cp * rcldb/(pi2d(i,k)*dthvx(i))
-                ent_eff   = 0.2 * 8. * tmp1
+                ent_eff   = min(0.2 * 8. * tmp1, 0.4)
 
                 radsum=0.
                 do kk = 1,kpbl(i)-1

--- a/bl_ysu.F90
+++ b/bl_ysu.F90
@@ -852,7 +852,7 @@
                           - (thlix(i,k) + thx(i,k)  *ep1*(qvx(i,k)  +qcxl(i,k)))
                 dthvx(i)  = max(dthvx(i),0.1)
                 tmp1      = xlv/cp * rcldb/(pi2d(i,k)*dthvx(i))
-                ent_eff   = 0.2 * 8. * tmp1 +0.2
+                ent_eff   = 0.2 * 8. * tmp1
 
                 radsum=0.
                 do kk = 1,kpbl(i)-1


### PR DESCRIPTION
A study by Zhang et al. showed that the downward mixing is over-estimated by the existing topdown_mixing option and suggested a fix. Other global simulations also show that the code would occasionally blow up due to this overly downward mixing. This PR follows that study and reduces the downward mixing.

Zhang, L., H. Shi, S.-H. Gao and S. Li, 2024: Overestimated Fog-Top Entrainment in WRF Simulation Leading
to Unrealistic Dissipation of Sea Fog: A Case Study. Remote Sens. 2024, 16, 1656. https://doi.org/10.3390/rs16101656.